### PR TITLE
[bt#15025] Fixed Packstation handling when generating labels, added tracking to dhl

### DIFF
--- a/delivery_dhl_de/models/delivery_carrier.py
+++ b/delivery_dhl_de/models/delivery_carrier.py
@@ -104,7 +104,11 @@ class DeliveryCarrier(models.Model):
             record.dhl_de_account_number = account_number
 
     def dhl_de_get_tracking_link(self, picking):
-        raise UserError(_("This feature is under development"))
+        if not picking.carrier_tracking_ref:
+            raise(_(
+                'Picking {} is missing a tracking reference'.format(picking.name)
+            ))
+        return 'https://www.dhl.com/de-de/home/tracking.html?tracking-id={}'.format(picking.carrier_tracking_ref)
 
     def dhl_de_cancel_shipment(self, pickings):
         raise UserError(_("This feature is under development"))

--- a/delivery_dhl_de/models/dhl_request.py
+++ b/delivery_dhl_de/models/dhl_request.py
@@ -116,6 +116,7 @@ class DHLProvider:
         address = self.cis_factory.ReceiverNativeAddressType()
         country = self.cis_factory.CountryType()
         communication = self.cis_factory.CommunicationType()
+        packstation = {}
         receiver.name1 = partner.name
         receiver.Address = address
         street, street_no = carrier.get_street_and_number_from_partner(partner)
@@ -128,6 +129,19 @@ class DHLProvider:
         address.city = partner.city
         address.Origin = country
         country.countryISOCode = partner.country_id and partner.country_id.code or ""
+        if any('packstation' in s for s in [street_no.lower(), partner.street2.lower()]):
+            address.streetName = 'Packstation'
+            if len(street.split(' ')) > 1:
+                packstation['packstationNumber'] = street.split(' ')[0]
+                packstation['postNumber'] = street.split(' ')[1]
+                address.streetNumber = street.split(' ')[0]
+                address.name2 = street.split(' ')[1]
+            else:
+                packstation['packstationNumber'] = street_no
+                packstation['postNumber'] = street
+                address.streetNumber = street_no
+                address.name2 = street
+            receiver.Packstation = packstation
         if partner.email:
             communication.email = partner.email
         receiver.Communication = communication


### PR DESCRIPTION
restart service

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec-group.com/web#view_type=form&model=helpdesk.ticket&id=15025">[bt#15025] NETA Prod: DHL Connector Missing Features</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>delivery_dhl_de</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->