### PR TITLE
[t127621] Show delivery number in PostLogistics and DHL labels

### DIFF
--- a/delivery_postlogistics/postlogistics/web_service.py
+++ b/delivery_postlogistics/postlogistics/web_service.py
@@ -252,6 +252,8 @@ class PostlogisticsWebService(object):
             attributes["proClima"] = False
 
         attributes["przl"] = services
+        free_text_max_len = 34
+        attributes["freeText"] = picking.name[:free_text_max_len]
 
         return attributes
 


### PR DESCRIPTION


<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.bt-group.com/web#view_type=form&model=project.task&id=127621">[t127621] [mt13145] NETA: All Shops | Add Delivery Number to the Delivery Label</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>delivery_dhl_de</td><td>.py</td></tr>
<tr><td>delivery_postlogistics</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->