### PR TITLE
[bt#19442] Re: MSHOP orders from Amazon are currently not imported in…

### DIFF
--- a/delivery_dhl_de/models/stock_picking.py
+++ b/delivery_dhl_de/models/stock_picking.py
@@ -67,6 +67,7 @@ class StockPicking(models.Model):
                     carrier
                     and carrier.allows_dhl_validation()
                     and carrier.delivery_type == "dhl_de"
+                    and not self.env.context.get('sale_amazon_get_order')
                 ):
                     (is_address_valid, validation_dhl,) = sp.carrier_id.dhl_validation(
                         sp, None


### PR DESCRIPTION
…to Odoo

Adding context for amazon DHL Verification.

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.bt-group.com/web#view_type=form&model=helpdesk.ticket&id=19442">[bt#19442] Re: MSHOP orders from Amazon are currently not imported into Odoo (#5877)</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>delivery_dhl_de</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->