### PR TITLE
[bt#19438] Fix DHL Response Handling

### DIFF
--- a/delivery_dhl_de/models/dhl_request.py
+++ b/delivery_dhl_de/models/dhl_request.py
@@ -224,6 +224,14 @@ class DHLProvider:
         shipment_response_element = response_element_xml.find(
             find_response_element_name, response_element_xml.nsmap
         )
-        Response = self.client.get_element(response_element_name)
-        response_zeep = Response.type.parse_xmlelement(shipment_response_element)
+        response = self.client.get_element(response_element_name)
+        resp_type = response.type
+        schema = self.client.wsdl.types
+        schema.settings.strict = False
+        response_zeep = response.type.parse_xmlelement(
+            shipment_response_element,
+            schema=schema,
+            schema_type=resp_type
+        )
+
         return response_zeep


### PR DESCRIPTION
Fixes errors when handling DHL web service responses for delivery validations.

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.bt-group.com/web#view_type=form&model=helpdesk.ticket&id=19438">[bt#19438] Re: MSHOP 103  Orders cannot be processed (#5873)</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>delivery_dhl_de</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->